### PR TITLE
The `node_modules` directory is excluded by default

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,5 @@
 		"noEmitOnError": true,
 		"forceConsistentCasingInFileNames": true,
 		"skipLibCheck": true
-	},
-	"exclude": [
-		"node_modules"
-	]
+	}
 }


### PR DESCRIPTION
See official TS docs: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html
Or do you intent to keep it there for clarity?

*strangely, I can't upload screenshots to Github atm; I don't know why*
Just search for `node_modules` in tsconfig docs. It is the second hit.

Nice config btw :wink: 