### PR TITLE
add noImplicitAny

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
 		"newLine": "lf",
 		"stripInternal": true,
 		"strict": true,
+		"noImplicitAny": true,
 		"noImplicitReturns": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,


### PR DESCRIPTION
In order to have typings when required this is a better choice than having the TSLint rule `typedef`.

See xojs/tslint-xo#14 for error descriptions and xojs/tslint-xo#13 for the initial thoughts why this is nice to have.
