### PR TITLE
Change outDir in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ $ npm install --save-dev @sindresorhus/tsconfig
 {
 	"extends": "@sindresorhus/tsconfig",
 	"compilerOptions": {
-		"outDir": "dist",
+		"outDir": ".",
 		"target": "es2018",
 		"lib": [
 			"es2018"


### PR DESCRIPTION
outDir is already `dist` in the config.

By the way, this `outDir` in your config somehow causes TS not to produce any files (if the folder is missing) like in https://github.com/bfred-it/delegate-it/pull/5/commits/62fc1914baa508ca1adcb47b40e049a573e17974 -> https://github.com/bfred-it/delegate-it/pull/5/commits/975d2277797ccf80cfb1912d880736b1591a1f14

`tsc --outDir dist` and the local `tsconfig.json` files work correctly, so this looks like an `extends`-specific bug. Perhaps it should be dropped until the bug it's fixed in TS