### PR TITLE
Remove moot `allowSyntheticDefaultImports` option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"esModuleInterop": true,
-		"allowSyntheticDefaultImports": true,
 		"resolveJsonModule": true,
 		"jsx": "react",
 		"sourceMap": true,


### PR DESCRIPTION
`--esModuleInterop` automatically enables `--allowSyntheticDefaultImports`.

https://www.typescriptlang.org/docs/handbook/compiler-options.html