### PR TITLE
Follow-up fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	},
 	"main": "tsconfig.json",
 	"engines": {
-		"node": ">=10"
+		"node": ">=12"
 	},
 	"files": [
 		"tsconfig.json"

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ $ npm install --save-dev @sindresorhus/tsconfig
 }
 ```
 
-When you are targeting a higher version of NodeJS check the relevant ECMA Version and add it as `target`:
+When you are targeting a higher version of Node.js, check the relevant ECMAScript version and add it as `target`:
 
 ```json
 {

--- a/readme.md
+++ b/readme.md
@@ -16,11 +16,19 @@ $ npm install --save-dev @sindresorhus/tsconfig
 {
 	"extends": "@sindresorhus/tsconfig",
 	"compilerOptions": {
+		"outDir": "dist"
+	}
+}
+```
+
+When you are targeting a higher version of NodeJS check the relevant ECMA Version and add it as `target`:
+
+```json
+{
+	"extends": "@sindresorhus/tsconfig",
+	"compilerOptions": {
 		"outDir": "dist",
-		"target": "es2018",
-		"lib": [
-			"es2018"
-		]
+		"target": "ES2021"
 	}
 }
 ```


### PR DESCRIPTION
I think removing `target` and `lib` from the minimal example in the readme is helpful to keep it as simple as possible. Personally I never used the `lib` part as providing a `target` already includes the required libs. 