### PR TITLE
Include DOM lib in types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
 		"target": "ES2019", // Node.js 12
 		"lib": [
 			"ES2019",
-			"ES2020.String"
+			"ES2020.String",
+			"DOM"
 		],
 		"moduleResolution": "node",
 		"allowSyntheticDefaultImports": true, // To provide backwards compatibility, Node.js allows you to import most CommonJS packages with a default import. This flag tells TypeScript that it's okay to use import on CommonJS modules.


### PR DESCRIPTION
As mentioned in https://github.com/sindresorhus/tsconfig/commit/f5aa5f572d4a0676c5259f9eae91e365ca40b946, adding a `lib` array breaks browser modules.

~~The _fun_ part is that I can't override it via my own tsconfig, it's just ignored, but if you add `"DOM"` to this array it works.~~ _I was adding `lib` instead of `compilerOptions.lib`. 🤦‍♂️_
