### PR TITLE
Suggest full path for the `extends` key

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ $ npm install --save-dev @sindresorhus/tsconfig
 
 ```json
 {
-	"extends": "@sindresorhus/tsconfig",
+	"extends": "@sindresorhus/tsconfig/tsconfig.json",
 	"compilerOptions": {
 		"outDir": "dist"
 	}
@@ -25,7 +25,7 @@ When you are targeting a higher version of Node.js, check the relevant ECMAScrip
 
 ```json
 {
-	"extends": "@sindresorhus/tsconfig",
+	"extends": "@sindresorhus/tsconfig/tsconfig.json",
 	"compilerOptions": {
 		"outDir": "dist",
 		"target": "ES2021"


### PR DESCRIPTION
You might not like this, but:

- this is the format suggested by TS’ docs: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#tsconfig-bases
- https://github.com/microsoft/vscode/issues/131643
	- (WebStorm does)

Feel free to close if unneeded though, I opened this here anyway because more editors might not support it