### PR TITLE
Add `DOM.Iterable` to libs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
 		"lib": [
 			"ES2019",
 			"ES2020.String",
-			"DOM"
+			"DOM",
+			"DOM.Iterable"
 		],
 		"moduleResolution": "node",
 		"allowSyntheticDefaultImports": true, // To provide backwards compatibility, Node.js allows you to import most CommonJS packages with a default import. This flag tells TypeScript that it's okay to use import on CommonJS modules.


### PR DESCRIPTION
I wish I know why this isn't included in `DOM`, but without this you can use:

```js
for (const childNode of node.childNodes) {
}
```
> TS2488: Type 'NodeListOf<ChildNode>' must have a '[Symbol.iterator]()' method that returns an iterator.

Which has been possible for a looooooong time.

<img width="1017" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/130801559-99e31a85-8338-4538-944a-1ca365a7f3af.png">

