### PR TITLE
Enable declarationMap for Go To Source Definition

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
 		"resolveJsonModule": false, // ESM doesn't yet support JSON modules.
 		"jsx": "react",
 		"declaration": true,
+		"declarationMap": true, // Enable Go To Source Definition with typescript > 4.7
 		"pretty": true,
 		"newLine": "lf",
 		"stripInternal": true,


### PR DESCRIPTION
Typescript 4.7 and vscode insiders has "Go To Source Definition" if the declarationMap is enabled. https://github.com/microsoft/TypeScript/issues/49003

This would make packages larger via the `.d.ts.map` as a tradeoff