### PR TITLE
Add `declarationMap` to go directly to .ts instead of .d.ts on action "Go to Definition"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
 		"resolveJsonModule": false, // ESM doesn't yet support JSON modules.
 		"jsx": "react",
 		"declaration": true,
+		"declarationMap": true,
 		"pretty": true,
 		"newLine": "lf",
 		"stripInternal": true,


### PR DESCRIPTION
This adds `declarationMap` to tsconfig.json, so that when executing IDE's feature of "Go to Definition", it will take you to the actual .ts source file instead of only the .d.ts declaration file.

This will improve DX in a lot of situations and should be the default. If for some reason, this was not the right config for a particular project setup, it can always be overwritten in the extended tsconfig.json.

Docs for declarationMap:
https://www.typescriptlang.org/tsconfig#declarationMap

All credits go to @gajus, who has posted it on the Birdsite:
https://twitter.com/kuizinas/status/1636641120477384705