### PR TITLE
Require Node.js 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	},
 	"main": "tsconfig.json",
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"files": [
 		"tsconfig.json"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,11 @@
 		"module": "node16",
 		"moduleResolution": "node16",
 		"moduleDetection": "force",
-		"target": "ES2021", // Node.js 16
+		"target": "ES2022", // Node.js 18
 		"lib": [
 			"DOM",
 			"DOM.Iterable",
-			"ES2021"
+			"ES2023"
 		],
 		"allowSyntheticDefaultImports": true, // To provide backwards compatibility, Node.js allows you to import most CommonJS packages with a default import. This flag tells TypeScript that it's okay to use import on CommonJS modules.
 		"resolveJsonModule": false, // ESM doesn't yet support JSON modules.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
 		"lib": [
 			"DOM",
 			"DOM.Iterable",
-			"ES2023"
+			"ES2022"
 		],
 		"allowSyntheticDefaultImports": true, // To provide backwards compatibility, Node.js allows you to import most CommonJS packages with a default import. This flag tells TypeScript that it's okay to use import on CommonJS modules.
 		"resolveJsonModule": false, // ESM doesn't yet support JSON modules.


### PR DESCRIPTION
Similar to 3ae0110ab3f1db30f4009b56cded744aa5218b71 this updates to Node.js 18.

As [Node.js is end of life since 2023-09-11](https://nodejs.dev/en/about/releases/) this updates the config to Node.js 18. This change is inspired by 3ae0110ab3f1db30f4009b56cded744aa5218b71 and [@tsconfig/node18](https://www.npmjs.com/package/@tsconfig/node18).