### PR TITLE
Drop redundant `allowSyntheticDefaultImports`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
 			"DOM.Iterable",
 			"ES2022"
 		],
-		"allowSyntheticDefaultImports": true, // To provide backwards compatibility, Node.js allows you to import most CommonJS packages with a default import. This flag tells TypeScript that it's okay to use import on CommonJS modules.
 		"resolveJsonModule": false, // ESM doesn't yet support JSON modules.
 		"jsx": "react",
 		"declaration": true,


### PR DESCRIPTION
[allowSyntheticDefaultImports](https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports) is implied by [esModuleInterop](https://www.typescriptlang.org/tsconfig#esModuleInterop), which is true when [module](https://www.typescriptlang.org/tsconfig#module) is `node16`

It _might_ be useful to people who alter `module` though, which is something I sometimes have to do.


Related:

- https://github.com/sindresorhus/tsconfig/pull/6
- https://github.com/sindresorhus/tsconfig/pull/25