### PR TITLE
Use `"jsx": "react-jsx"`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
 			"ES2022" // Node.js 18
 		],
 		"resolveJsonModule": false, // ESM doesn't yet support JSON modules.
-		"jsx": "react",
+		"jsx": "react-jsx",
 		"declaration": true,
 		"newLine": "lf",
 		"stripInternal": true,


### PR DESCRIPTION
5 years later, might be time? 😅 

https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#how-to-upgrade-to-the-new-jsx-transform