### PR TITLE
Enable rewriteRelativeImportExtensions option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
 		"noUncheckedIndexedAccess": true,
 		"noPropertyAccessFromIndexSignature": true,
 		"noUncheckedSideEffectImports": true,
+		"rewriteRelativeImportExtensions": true,
 		"noEmitOnError": true,
 		"useDefineForClassFields": true,
 		"forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
To stop import `.js` in typescript files

https://www.typescriptlang.org/tsconfig/#rewriteRelativeImportExtensions
